### PR TITLE
Add remote boop functionality with LoRa module AT commands

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -11,4 +11,4 @@ Assembly and putting up with Kay - Colin and Matt at PCBx.io.
 Soldering on battery packs - @Fujimaru_husky
 
 Additional Contributors:
-Software (minor feature: scritch) - dani.pink
+Software (basic radio stuff) - dani.pink

--- a/initfs/credits.txt
+++ b/initfs/credits.txt
@@ -7,4 +7,4 @@ Software and Build Toolchain - Naomi Kirby
 Ideas and maybe software someday - NullFox
 Assembly and putting up with Kay - Colin and Matt at PCBx.io.
 Soldering on battery packs - @Fujimaru_husky
-Software (minor feature: scritch) - dani.pink
+Software (basic radio stuff) - dani.pink

--- a/initfs/lora_e5_radio.py
+++ b/initfs/lora_e5_radio.py
@@ -1,0 +1,120 @@
+# This file contains code for interacting with the SEEED LoRa-E5 HF module using AT commands (in AT+TEST mode)
+# This is by no means the best way of using the capabilities of the radio module, but it lets us accomplish some
+# very basic P2P functionality without needing to use a special programmer to load new firmware onto the LoRa module.
+
+# The functions in this file handle:
+# 1) initializing the radio module into AT+TEST mode and setting the receive parameters to reasonable values
+# 2)
+
+
+# NOTE: We are using power level 5 dBm here, whereas 14 dBm is the max. I had some issues where badge would come disconnected
+# from USB while trying to use the higher transmit power. It might work okay to use the higher power on battery though, but the
+# range seems okay with 5 dBm so for now I am leaving it.
+from machine import Timer, Pin, UART
+import time
+
+class LoraE5Radio():
+    def __init__(self, uart_baudrate=9600, uart_tx_pin=8, uart_rx_pin=9, uart_timeout=250):
+        self.radio_uart = UART(1, baudrate=uart_baudrate, tx=Pin(uart_tx_pin), rx=Pin(uart_rx_pin), timeout=uart_timeout)
+
+        self.rx_buf = b""
+        self.last_rx_arm = time.ticks_ms()
+        self.rx_is_armed = False
+        self.init_radio()
+        self.arm_radio_rx()
+
+    def init_radio(self):
+        print(self.send_at("AT"))
+        print(self.send_at("AT+MODE=TEST"))
+        print(self.send_at("AT+TEST=RFCFG,903.3,SF7,125,12,15,5,ON,OFF,OFF"))
+
+    def arm_radio_rx(self, verbose=False, delay_ms=100):
+        self.rx_is_armed = True
+        if verbose:
+            print(self.send_at("AT+TEST=RXLRPKT", delay_ms=delay_ms))
+        else:
+            self.send_at("AT+TEST=RXLRPKT", delay_ms=delay_ms)
+
+    def flush_uart(self):
+        # drain any stale bytes
+        while self.radio_uart.any():
+            self.radio_uart.read()
+            time.sleep_ms(5)
+
+    def send_at(self, cmd, delay_ms=200):
+        self.flush_uart()
+        self.radio_uart.write(cmd + "\r\n")
+        time.sleep_ms(delay_ms)
+        resp = b""
+        # read whatever arrived
+        while self.radio_uart.any():
+            chunk = self.radio_uart.read()
+            if chunk:
+                resp += chunk
+            time.sleep_ms(10)
+        # return plain text (ignore decode errors)
+        return resp.decode('utf-8', 'ignore').strip()
+
+    def hex_to_ascii(self,s):
+        # incoming payload appears as hex bytes (e.g. 48656C6C6F...)
+        try:
+            b = bytes.fromhex(s)
+            # decode ASCII but fall back to repr if weird bytes
+            try:
+                return b.decode('utf-8')
+            except:
+                return str(b)
+        except:
+            return None
+            
+    def check_for_boop_message(self, expected_msg="boop"):
+        # checks to see if boop message received since last call
+        # collect any incoming bytes
+        found_boop = False
+        if self.radio_uart.any():
+            self.rx_buf += self.radio_uart.read()
+
+            # pull out complete lines (delimited by \n)
+            while b"\n" in self.rx_buf:
+                line_bytes, self.rx_buf = self.rx_buf.split(b"\n", 1)
+                line = line_bytes.decode("utf-8", "ignore").strip()
+                if not line:
+                    continue
+
+                # show raw UART content for debugging
+                # print("RAW:", line)
+
+                # examples the modem emits:
+                # +TEST: LEN:12, RSSI:-45, SNR:10
+                # +TEST: RX "48656C6C6F20576F726C6421"
+                if line.startswith("+TEST: RX"):
+                    q1 = line.find('"')
+                    q2 = line.rfind('"')
+                    payload_hex = None
+                    if q1 != -1 and q2 != -1 and q2 > q1 + 1:
+                        payload_hex = line[q1+1:q2]
+                    msg = self.hex_to_ascii(payload_hex) if payload_hex else None
+                    if msg is not None:
+                        print("RX ASCII:", msg)
+                        if msg == expected_msg:
+                            found_boop = True
+                    else:
+                        print("RX RAW  :", line)
+                else:
+                    # print(line) # print RSSI/SNR for debugging
+                    pass
+
+        if time.ticks_diff(time.ticks_ms(), self.last_rx_arm) > 15000:
+            # Periodically re-arm radio
+            self.arm_radio_rx()
+            self.last_rx_arm = time.ticks_ms()
+            
+        return found_boop
+
+    def tx_boop(self, msg="boop", arm_rx_after_sent=False):
+        # TX as string; receiver will report hex of the same bytes
+        print(self.send_at('AT+TEST=TXLRSTR,"{}"'.format(msg), delay_ms=150))
+        self.rx_is_armed = False
+        if arm_rx_after_sent:
+            time.sleep_ms(100)
+        self.arm_radio_rx()

--- a/initfs/lora_e5_radio.py
+++ b/initfs/lora_e5_radio.py
@@ -1,10 +1,11 @@
-# This file contains code for interacting with the SEEED LoRa-E5 HF module using AT commands (in AT+TEST mode)
+# This file contains code for interacting with the Seeed Studio LoRa-E5 HF module using AT commands (in AT+TEST mode)
 # This is by no means the best way of using the capabilities of the radio module, but it lets us accomplish some
 # very basic P2P functionality without needing to use a special programmer to load new firmware onto the LoRa module.
 
 # The functions in this file handle:
 # 1) initializing the radio module into AT+TEST mode and setting the receive parameters to reasonable values
-# 2)
+# 2) transmitting a "boop" message
+# 3) checking for and identifying received "boop" messages
 
 
 # NOTE: We are using power level 4 dBm here, whereas 14 dBm is the max. I had some issues where badge would come disconnected

--- a/initfs/lora_e5_radio.py
+++ b/initfs/lora_e5_radio.py
@@ -99,7 +99,8 @@ class LoraE5Radio():
                         if msg == expected_msg:
                             found_boop = True
                     else:
-                        print("RX RAW  :", line)
+                        # print("RX RAW  :", line) # print full line for debugging
+                        pass
                 else:
                     # print(line) # print RSSI/SNR for debugging
                     pass

--- a/initfs/lora_e5_radio.py
+++ b/initfs/lora_e5_radio.py
@@ -7,9 +7,9 @@
 # 2)
 
 
-# NOTE: We are using power level 5 dBm here, whereas 14 dBm is the max. I had some issues where badge would come disconnected
+# NOTE: We are using power level 4 dBm here, whereas 14 dBm is the max. I had some issues where badge would come disconnected
 # from USB while trying to use the higher transmit power. It might work okay to use the higher power on battery though, but the
-# range seems okay with 5 dBm so for now I am leaving it.
+# range seems okay with 4 dBm so for now I am leaving it.
 from machine import Timer, Pin, UART
 import time
 
@@ -24,10 +24,10 @@ class LoraE5Radio():
         self.arm_radio_rx()
 
     def init_radio(self):
-        time.sleep_ms(300) # Seems to sometimes help when turning on after a long time of being off
+        time.sleep_ms(350) # Seems to sometimes help when turning on after a long time of being off
         print(self.send_at("AT", delay_ms=100))
         print(self.send_at("AT+MODE=TEST", delay_ms=100))
-        print(self.send_at("AT+TEST=RFCFG,903.3,SF7,125,12,15,5,ON,OFF,OFF", delay_ms=100))
+        print(self.send_at("AT+TEST=RFCFG,903.3,SF7,125,12,15,4,ON,OFF,OFF", delay_ms=100))
 
     def arm_radio_rx(self, verbose=False, delay_ms=100):
         self.rx_is_armed = True
@@ -114,7 +114,7 @@ class LoraE5Radio():
         return found_boop
 
     def tx_boop(self, msg="boop", arm_rx_after_sent=False):
-        print(self.send_at('AT+TEST=TXLRSTR,"{}"'.format(msg), delay_ms=150))
+        print(self.send_at('AT+TEST=TXLRSTR,"{}"'.format(msg), delay_ms=125))
         self.rx_is_armed = False
         if arm_rx_after_sent:
             time.sleep_ms(100)

--- a/initfs/lora_e5_radio.py
+++ b/initfs/lora_e5_radio.py
@@ -113,8 +113,8 @@ class LoraE5Radio():
             
         return found_boop
 
-    def tx_boop(self, msg="boop", arm_rx_after_sent=False):
-        print(self.send_at('AT+TEST=TXLRSTR,"{}"'.format(msg), delay_ms=125))
+    def tx_boop(self, msg="boop", delay_ms=150, arm_rx_after_sent=False):
+        print(self.send_at('AT+TEST=TXLRSTR,"{}"'.format(msg), delay_ms=delay_ms))
         self.rx_is_armed = False
         if arm_rx_after_sent:
             time.sleep_ms(100)

--- a/initfs/lora_e5_radio.py
+++ b/initfs/lora_e5_radio.py
@@ -24,9 +24,10 @@ class LoraE5Radio():
         self.arm_radio_rx()
 
     def init_radio(self):
-        print(self.send_at("AT"))
-        print(self.send_at("AT+MODE=TEST"))
-        print(self.send_at("AT+TEST=RFCFG,903.3,SF7,125,12,15,5,ON,OFF,OFF"))
+        time.sleep_ms(300) # Seems to sometimes help when turning on after a long time of being off
+        print(self.send_at("AT", delay_ms=100))
+        print(self.send_at("AT+MODE=TEST", delay_ms=100))
+        print(self.send_at("AT+TEST=RFCFG,903.3,SF7,125,12,15,5,ON,OFF,OFF", delay_ms=100))
 
     def arm_radio_rx(self, verbose=False, delay_ms=100):
         self.rx_is_armed = True
@@ -113,7 +114,6 @@ class LoraE5Radio():
         return found_boop
 
     def tx_boop(self, msg="boop", arm_rx_after_sent=False):
-        # TX as string; receiver will report hex of the same bytes
         print(self.send_at('AT+TEST=TXLRSTR,"{}"'.format(msg), delay_ms=150))
         self.rx_is_armed = False
         if arm_rx_after_sent:

--- a/initfs/main.py
+++ b/initfs/main.py
@@ -263,9 +263,14 @@ class badge(object):
                 and not self.touch_start_time[3]
             )
             or (
-                self.touch.channels[0].level < 0.2
-                and self.touch.channels[1].level < 0.2
-                and self.touch.channels[3].level < 0.2
+                
+               self.touch.channels[2].level - max(self.touch.channels[0].level, self.touch.channels[1].level, self.touch.channels[3].level) > 0.2
+            
+            )
+            or (
+                self.touch.channels[0].level < 0.23
+                and self.touch.channels[1].level < 0.23
+                and self.touch.channels[3].level < 0.23
             )
             and (
                 (
@@ -350,7 +355,7 @@ class badge(object):
             self.scritch_mix = max(min(self.scritch_mix_target, 1.0) - 0.03, 0)
             self.scritch_mix_target = max(self.scritch_mix_target - 0.03, 0)
         
-        if self.scritch_mix == 0 and self.boop_mix == 0:
+        if self.scritch_mix == 0 and self.boop_count == 0:
             self.prevent_isr_update = False
 
         self.sw4_state <<= 1
@@ -407,7 +412,7 @@ class badge(object):
     def run(self):
         while True:
             # Run touch reading update more often than animtion update, to detect swipes/scritches better
-            for _ in range(10):
+            for _ in range(20):
                 if self.prevent_isr_update:
                     # Shorter sleep time to compensate for not having isr update
                     time.sleep_ms(1)

--- a/initfs/main.py
+++ b/initfs/main.py
@@ -237,7 +237,7 @@ class badge(object):
 
     def isr_update(self,*args):
         if not self.prevent_isr_update:
-            schedule(self.update, self)
+            schedule(self.update, True)
 
     def touch_readings_update(self):
         self.touch.update()
@@ -302,6 +302,8 @@ class badge(object):
         return True
         
     def update(self,*args):
+        if args[0] and self.prevent_isr_update:
+            return
         current_time = time.ticks_ms()
         self.last_boop_level = self.boop_level
         self.boop_level = self.touch.channels[2].level
@@ -403,7 +405,7 @@ class badge(object):
         self.disp.update()
         if (self.boop_mix > 0.0):
             self.boop_offset += 1
-        if (self.boop_mix > 0.0) or (self.scritch_mix > 0.0):
+        if (self.boop_mix > 0.0) or (self.scritch_mix > 0.0) and backup:
             for i in range(len(backup)):
                 self.disp.downward[i].copy(backup[i])
 
@@ -419,7 +421,7 @@ class badge(object):
                 else:
                     time.sleep_ms(5)
                 self.touch_readings_update()
-            self.update()
+            self.update(False)
 
 
 global t

--- a/initfs/main.py
+++ b/initfs/main.py
@@ -314,7 +314,7 @@ class badge(object):
             self.boop_count = 20
         elif self.radio.check_for_boop_message():
             # Detect LoRa packet from boop on nearby badge
-            print("detected remote boop")
+            print("Detected remote boop")
             self.prevent_isr_update = True
             self.boop_offset = 0
             self.boop_mix    = 1.0
@@ -419,4 +419,4 @@ class badge(object):
 
 global t
 t = badge()
-t.run()
+#t.run()


### PR DESCRIPTION
This PR makes it so booping one badge also triggers a boop (with green instead white animation) on nearby badges.

To do this, I am using the basic AT+TEST commands to send and receive raw LoRa packets with the Seeed Studio LoRa E5 HF module. It doesn't use LoRaWAN or Meshtastic or anything like that, so functionality is limited but at least it can be used without having to load custom firmware onto the LoRa module itself by way of extra programming hardware.

https://github.com/user-attachments/assets/ed8e07b7-114a-450a-b89b-ae9b31523edc

Potential future extensions:
- Make more different messages to do more things.
- Use the color of the boop animation on badges that receive the command over LoRa to indicate the RSSI. Theoretically one could use that to estimate how far away the transmitting badge was.
- Figure out a reliable way to do higher power transmission (see comments at top of `lora_e5_radio.py`; I was seeing a power spike issue)
- Use asyncio to make it so the delays on the boop transmission functionality, or the radio initialization functionality, don't delay the main loop. As-is, we are adding a 350ms extra time to the start-up of the badge (time from when the switch is flipped on to when the LEDs turn on) to give the radio time to initialize. Similarly, we wait 150ms from the time of a boop to when the animation properly plays, for the radio module to have time to transmit the packet and print a confirmation message to UART. With asyncio, we could probably get rid of those delays.
- Meshtastic, of course, but that would require a totally different strategy to implement.